### PR TITLE
Undefined interactions at line 211 fix for mobile 

### DIFF
--- a/infinite-slider.js
+++ b/infinite-slider.js
@@ -208,11 +208,11 @@
                 interactionCurrent.y += dy;
               }
             }
-            // had to add this to avoid getting undefined at line 211 when clicking google maps
+            // had to add this to avoid getting undefined at line 211 when overlaying and clicking google maps
             // this seems like a hack, if you know of a better solution please delete this.
-            // *** start of added code
+            // *** start of added code - didn't think about y, added it, thanks
                if (!interactionStart && !interactionCurrent) {
-                  interactionStart = interactionCurrent = { x: 0};
+                  interactionStart = interactionCurrent = { x: 0, y:0};
                  
             } else if (!interactionStart && interactionCurrent) {
                 interactionStart = interactionCurrent;

--- a/infinite-slider.js
+++ b/infinite-slider.js
@@ -208,6 +208,18 @@
                 interactionCurrent.y += dy;
               }
             }
+            // had to add this to avoid getting undefined at line 211 when clicking google maps
+            // this seems like a hack, if you know of a better solution please delete this.
+            // *** start of added code
+               if (!interactionStart && !interactionCurrent) {
+                  interactionStart = interactionCurrent = { x: 0};
+                 
+            } else if (!interactionStart && interactionCurrent) {
+                interactionStart = interactionCurrent;
+            } else if (interactionStart && !interactionCurrent) {
+                 interactionCurrent = interactionStart;
+            }
+            // ** end of added code
             xCont = elementStartX + (interactionCurrent.x - interactionStart.x);
             return doTransform();
           };


### PR DESCRIPTION
This is a temporary fix/hack for when using this slider with Angular 1.5.3 overlaying google maps on mobile (iOS and Android). It prevents the slider from breaking on the mobile when using it as an overlay over angular ui google maps. Everything works fine on desktop. After swiping through a few selections and then selecting the google map, the  slider breaks, everytime I click the google map it says undefined interactions. This may be a google maps issue, but  I have not nailed down entirely. It seems like a complete edge case. Let me know if you've run into this issue before and what you think may be causing it. 
